### PR TITLE
Fix the girder strut model to be compatible with shaders

### DIFF
--- a/src/main/resources/assets/bits_n_bobs/models/block/girder_strut/girder.json
+++ b/src/main/resources/assets/bits_n_bobs/models/block/girder_strut/girder.json
@@ -1,119 +1,54 @@
 {
-	"format_version": "1.21.6",
-	"credit": "Made with Blockbench",
-	"parent": "block/block",
-	"textures": {
-		"0": "create:block/girder",
-		"particle": "create:block/industrial_iron_block"
-	},
-	"elements": [
-		{
-			"from": [6, 4, 0],
-			"to": [10, 12, 16],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
-			"faces": {
-				"north": {"uv": [8, 1, 12, 3], "rotation": 270, "texture": "#0"},
-				"east": {"uv": [0, 5, 8, 9], "texture": "#0"},
-				"south": {"uv": [8, 1, 12, 3], "rotation": 270, "texture": "#0"},
-				"west": {"uv": [0, 5, 8, 9], "texture": "#0"}
-			}
-		},
-		{
-			"from": [4, 2, 0],
-			"to": [12, 4, 16],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
-			"faces": {
-				"north": {"uv": [12, 2, 16, 3], "texture": "#0"},
-				"east": {"uv": [0, 4, 8, 5], "rotation": 180, "texture": "#0"},
-				"south": {"uv": [12, 2, 16, 3], "texture": "#0"},
-				"west": {"uv": [0, 4, 8, 5], "rotation": 180, "texture": "#0"},
-				"up": {"uv": [8, 0, 16, 4], "rotation": 90, "texture": "#0"},
-				"down": {"uv": [0, 0, 8, 4], "rotation": 90, "texture": "#0"}
-			}
-		},
-		{
-			"from": [4, 12, 0],
-			"to": [12, 14, 16],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
-			"faces": {
-				"north": {"uv": [12, 1, 16, 2], "texture": "#0"},
-				"east": {"uv": [0, 4, 8, 5], "texture": "#0"},
-				"south": {"uv": [12, 1, 16, 2], "texture": "#0"},
-				"west": {"uv": [0, 4, 8, 5], "texture": "#0"},
-				"up": {"uv": [0, 0, 8, 4], "rotation": 270, "texture": "#0"},
-				"down": {"uv": [8, 0, 16, 4], "rotation": 270, "texture": "#0"}
-			}
-		}
-	],
-	"display": {
-		"thirdperson_righthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"thirdperson_lefthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, 45, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"firstperson_lefthand": {
-			"rotation": [0, -135, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"ground": {
-			"translation": [0, 3, 0],
-			"scale": [0.25, 0.25, 0.25]
-		},
-		"gui": {
-			"rotation": [30, -135, 0],
-			"scale": [0.625, 0.625, 0.625]
-		},
-		"fixed": {
-			"scale": [0.5, 0.5, 0.5]
-		}
-	},
-	"groups": [
-		{
-			"name": "Beam X",
-			"origin": [8, 13, 8],
-			"color": 0,
-			"children": [0, 1, 2]
-		},
-		{
-			"name": "Brace",
-			"origin": [0, 0, 0],
-			"color": 0,
-			"children": []
-		},
-		{
-			"name": "girder_strut_attachment",
-			"origin": [8, 8, 8],
-			"color": 0,
-			"children": [
-				{
-					"name": "Brace",
-					"origin": [0, 0, 0],
-					"color": 0,
-					"children": []
-				},
-				{
-					"name": "girder_strut_attachment",
-					"origin": [8, 8, 8],
-					"color": 0,
-					"children": [
-						{
-							"name": "Brace",
-							"origin": [0, 0, 0],
-							"color": 0,
-							"children": []
-						}
-					]
-				}
-			]
-		}
-	]
+  "format_version": "1.21.6",
+  "credit": "Made with Blockbench",
+  "textures": {
+    "0": "create:block/girder",
+    "particle": "create:block/industrial_iron_block"
+  },
+  "elements": [
+    {
+      "from": [6, 4, 0],
+      "to": [10, 12, 16],
+      "rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 8]},
+      "faces": {
+        "north": {"uv": [8, 1, 12, 3], "rotation": 270, "texture": "#0"},
+        "east": {"uv": [0, 5, 8, 9], "texture": "#0"},
+        "south": {"uv": [8, 1, 12, 3], "rotation": 270, "texture": "#0"},
+        "west": {"uv": [0, 5, 8, 9], "texture": "#0"}
+      }
+    },
+    {
+      "from": [4, 2, 0],
+      "to": [12, 4, 16],
+      "faces": {
+        "north": {"uv": [12, 2, 16, 3], "texture": "#0"},
+        "east": {"uv": [0, 4, 8, 5], "rotation": 180, "texture": "#0"},
+        "south": {"uv": [12, 2, 16, 3], "texture": "#0"},
+        "west": {"uv": [0, 4, 8, 5], "rotation": 180, "texture": "#0"},
+        "up": {"uv": [8, 0, 16, 4], "rotation": 90, "texture": "#0"},
+        "down": {"uv": [0, 0, 8, 4], "rotation": 90, "texture": "#0"}
+      }
+    },
+    {
+      "from": [4, 12, 0],
+      "to": [12, 14, 16],
+      "rotation": {"angle": 0, "axis": "y", "origin": [8, 13, 8]},
+      "faces": {
+        "north": {"uv": [12, 1, 16, 2], "texture": "#0"},
+        "east": {"uv": [0, 4, 8, 5], "texture": "#0"},
+        "south": {"uv": [12, 1, 16, 2], "texture": "#0"},
+        "west": {"uv": [0, 4, 8, 5], "texture": "#0"},
+        "up": {"uv": [0, 0, 8, 4], "rotation": 270, "texture": "#0"},
+        "down": {"uv": [8, 0, 16, 4], "rotation": 270, "texture": "#0"}
+      }
+    }
+  ],
+  "groups": [
+    {
+      "name": "Beam Z",
+      "origin": [8, 13, 8],
+      "color": 0,
+      "children": [0, 1, 2]
+    }
+  ]
 }


### PR DESCRIPTION
Changed the normal girder strut model to match the weathered girder strut model. This fixes normal girder struts glowing pink and having holes when shaders are enabled. Tested with Photon, Complementary and Bliss shaders.