### PR TITLE
Fix dedicated server crash with Azimuth

### DIFF
--- a/src/main/java/com/kipti/bnb/registry/azimuth/BnbCreateBlockEdits.java
+++ b/src/main/java/com/kipti/bnb/registry/azimuth/BnbCreateBlockEdits.java
@@ -4,12 +4,9 @@ import com.cake.azimuth.foundation.preconstruct.AzPreConstructEventListener;
 import com.cake.azimuth.registration.event.RegisterCreateBlockEditsEvent;
 import com.kipti.bnb.content.decoration.dyeable.pipes.DyeablePipeBlockItem;
 import com.kipti.bnb.content.decoration.dyeable.simple.SimpleDyeableBlockItem;
-import com.kipti.bnb.content.decoration.dyeable.simple.SimpleDyeableModelWrapper;
-import com.kipti.bnb.registry.client.BnbSpriteShifts;
-import com.simibubi.create.content.kinetics.steamEngine.SteamEngineBlock;
-import com.simibubi.create.foundation.data.CreateRegistrate;
-import com.tterrag.registrate.builders.BlockBuilder;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.FMLEnvironment;
 
 public class BnbCreateBlockEdits {
 
@@ -29,11 +26,9 @@ public class BnbCreateBlockEdits {
         event.forBlockItem("fluid_valve", SimpleDyeableBlockItem::new);
         event.forBlockItem("steam_engine", SimpleDyeableBlockItem::new);
 
-        event.forBlock(
-            "steam_engine",
-            builder -> ((BlockBuilder<SteamEngineBlock, CreateRegistrate>) builder).onRegister(CreateRegistrate.blockModel(
-                () -> (m) -> new SimpleDyeableModelWrapper(m, BnbSpriteShifts.DYED_STEAM_ENGINE)))
-        );
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            BnbCreateBlockEditsClient.register(event);
+        }
     }
 
 }

--- a/src/main/java/com/kipti/bnb/registry/azimuth/BnbCreateBlockEditsClient.java
+++ b/src/main/java/com/kipti/bnb/registry/azimuth/BnbCreateBlockEditsClient.java
@@ -1,0 +1,23 @@
+package com.kipti.bnb.registry.azimuth;
+
+import com.cake.azimuth.registration.event.RegisterCreateBlockEditsEvent;
+import com.kipti.bnb.content.decoration.dyeable.simple.SimpleDyeableModelWrapper;
+import com.kipti.bnb.registry.client.BnbSpriteShifts;
+import com.simibubi.create.content.kinetics.steamEngine.SteamEngineBlock;
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.tterrag.registrate.builders.BlockBuilder;
+
+final class BnbCreateBlockEditsClient {
+
+    private BnbCreateBlockEditsClient() {
+    }
+
+    static void register(final RegisterCreateBlockEditsEvent event) {
+        event.forBlock(
+                "steam_engine",
+                builder -> ((BlockBuilder<SteamEngineBlock, CreateRegistrate>) builder).onRegister(CreateRegistrate.blockModel(
+                        () -> model -> new SimpleDyeableModelWrapper(model, BnbSpriteShifts.DYED_STEAM_ENGINE)))
+        );
+    }
+
+}


### PR DESCRIPTION
###Description:
  This fixes a dedicated-server crash caused by client-only model classes being referenced from BnbCreateBlockEdits.( #134 )

  The Steam Engine model registration has been moved into a client-only helper, while the common Azimuth block-edit registration remains safe to load on dedicated servers.

  This prevents BakedModel from being loaded on the server when using Azimuth 1.4.2.

